### PR TITLE
Transition to TypeScript-based mock data for portfolio

### DIFF
--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -1,5 +1,5 @@
 import { SignupParams, LoginParams } from '../types/api';
-import db from '../db.json';
+import { db } from './mockData';
 
 // Helper to delay response for realistic feel
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/client/src/api/member.ts
+++ b/client/src/api/member.ts
@@ -1,6 +1,6 @@
 import { MemberStore } from '../store/MemberStore';
 import { UpdateMemberParams, GetMemberResponse } from '../types/api';
-import db from '../db.json';
+import { db } from './mockData';
 
 // Helper to delay response for realistic feel
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/client/src/api/mentee.ts
+++ b/client/src/api/mentee.ts
@@ -1,6 +1,6 @@
 import { CreateMenteeParams } from '../types/api';
 import { MenteeData } from '../types/mentee';
-import db from '../db.json';
+import { db } from './mockData';
 
 // Helper to delay response for realistic feel
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/client/src/api/mentor.ts
+++ b/client/src/api/mentor.ts
@@ -1,6 +1,6 @@
 import { Mentor } from '../types';
 import { CreateMentorParams, GetMentorListResponse, GetMentorListParams } from '../types/api';
-import db from '../db.json';
+import { db } from './mockData';
 
 // Helper to delay response for realistic feel
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));

--- a/client/src/api/mentoring.ts
+++ b/client/src/api/mentoring.ts
@@ -5,7 +5,7 @@ import {
 	GetMentoringListResponse,
 	Content,
 } from '../types/api/mentoring';
-import db from '../db.json';
+import { db } from './mockData';
 
 // Helper to delay response for realistic feel
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -56,8 +56,7 @@ export const getMentoringList = async (
 ): Promise<GetMentoringListResponse> => {
 	await delay(500);
 
-	// Join all mentorings with their mentor names for the list view
-	// The `Content` type in `GetMentoringListResponse` needs `mentorName`
+	// Join with mentor data to ensure all fields required by Content type are present
 	const allData: Content[] = db.mentorings.map(mentoring => {
 		const mentor = db.mentors.find(m => m.mentorId === mentoring.mentorId);
 		return {
@@ -67,7 +66,7 @@ export const getMentoringList = async (
 			field: mentoring.field || mentor?.field || '',
 			task: mentoring.task || mentor?.task || '',
 			career: mentoring.career || mentor?.career || '',
-		};
+		} as Content;
 	});
 
 	const totalElements = allData.length;

--- a/client/src/api/mockData.ts
+++ b/client/src/api/mockData.ts
@@ -1,4 +1,4 @@
-{
+export const db = {
   "members": [
     {
       "id": 1,
@@ -407,4 +407,4 @@
       "status": "completed"
     }
   ]
-}
+};

--- a/client/src/api/payments.ts
+++ b/client/src/api/payments.ts
@@ -1,4 +1,4 @@
-import db from '../db.json';
+import { db } from './mockData';
 
 // Use window.location.origin to support any deployment URL (S3, Vercel, Localhost)
 const appUrl = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000';


### PR DESCRIPTION
Transitioned the project's mock data source from a JSON file to a TypeScript module (`mockData.ts`) to ensure build reliability and provide a better developer experience for portfolio archiving. All API files were updated to import from the new TS module, and the data-joining logic was refined to ensure the UI remains fully populated. Unrelated `package-lock.json` changes were reverted.

---
*PR created automatically by Jules for task [13135724675524230721](https://jules.google.com/task/13135724675524230721) started by @qpwoei0123*